### PR TITLE
Update Temporal Property

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ NGSI-LD, that it is added by default to any `@context` sent to a request.
 
 [https://schema.lab.fiware.org/ld/fiware-datamodels-context.jsonld](https://schema.lab.fiware.org/ld/fiware-datamodels-context.jsonld)
 refers to the definition of standard data models supplied by FIWARE. Adding this to the `@context` will load the
-definitions of all the [data models](https://fiware-datamodels.readthedocs.io) defined by the FIWARE Foundation, a
+definitions of all the [data models](https://fiware-datamodels.readthedocs.io) defined by the FIWARE Foundation in collaboration with other organizations such as GSMA or TM Forum, a
 summary of the FQNs related to **Building** can be seen below:
 
 ```json
@@ -494,10 +494,9 @@ The `type` of a _property_ attribute must be one of the following:
 -   `"GeoProperty"`: `"http://uri.etsi.org/ngsi-ld/GeoProperty"` for locations. Locations should be specified as
     Longitude-Latitude pairs in [GeoJSON format](https://tools.ietf.org/html/rfc7946). The preferred name for the
     primary location attribute is `location`
--   `"TemporalProperty"`: `"http://uri.etsi.org/ngsi-ld/TemporalProperty"` for time-based values. Temporal properties
-    should be Date, Time or DateTime strings encoded be [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601) - e.g.
+-   `"Property"`: `"http://uri.etsi.org/ngsi-ld/Property"` - for everything else.
+-   For time-based values, `"Property"` shall be used as well, but the property value should be Date, Time or DateTime strings encoded in the [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601) - e.g.
     `YYYY-MM-DDThh:mm:ssZ`
--   `"Property"`: `"http://uri.etsi.org/ngsi-ld/Property"` - for everything else
 
 > **Note:** that for simplicity, this data entity has no relationships defined. Relationships must be given the
 > `type="Relationship`. Relationships will be discussed in a subsequent tutorial.


### PR DESCRIPTION
Temporal Properties are of internal use in the API and not used by API users. The proper encoding of Date and Time, as Properties is shown at

https://github.com/FIWARE/dataModels/blob/master/specs/ngsi-ld_howto.md#airquality-in-ngsi-ld-format

Probably it would be a good idea that this tutorial or further tutorials include DateTime encodings in their examples. 